### PR TITLE
add `on-headers` module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "bluebird": "^2.9.4",
     "browser-sync": "^2.0.0-rc3",
-    "connect-injector": "^0.4.2"
+    "connect-injector": "^0.4.2",
+    "on-headers": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
Fixes bug with `on-headers` being required but not installed.