### PR TITLE
remove `on-headers` unused dependency

### DIFF
--- a/lib/browsersync.js
+++ b/lib/browsersync.js
@@ -2,7 +2,6 @@
 
 var Promise = require('bluebird');
 var browserSync = require('browser-sync');
-var onHeaders = require('on-headers');
 var injector = require('connect-injector');
 
 function noop(){}


### PR DESCRIPTION
`on-headers` is not used and shouldn't be required