### PR TITLE
set logLevel='silent'

### DIFF
--- a/lib/browsersync.js
+++ b/lib/browsersync.js
@@ -7,7 +7,7 @@ var browserSync;
 module.exports = function(app){
   var self = this;
 
-  return startBroserSync({}).then(function(bs){
+  return startBroserSync({logSnippet: false}).then(function(bs){
     var snippet = bs.options.get('snippet');
     var queue = [];
     var timer;


### PR DESCRIPTION
removes undesired msg in console

```Copy the following snippet into your website, just before the closing </body> tag
<script type='text/javascript' id="__bs_script__">//<![CDATA[
    document.write("<script async src='http://HOST:3000/browser-sync/browser-sync-client.2.2.3.js'><\/script>".replace("HOST", location.hostname));
//]]></script>```

http://www.browsersync.io/docs/options/#option-logLevel

solves https://github.com/hexojs/hexo-browsersync/issues/4