### PR TITLE
Introduce an option to change tag to inject Browsersync snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ browsersync:
   ghostMode:
     scroll: true
   instanceName: "uniqueString"
+  injectTag: "<body>"
 ````
 
 You can check [BrowserSync options](http://www.browsersync.io/docs/options/) for more info. 
 
-N.B.: `logSnippet` is disabled by default. Also, `instanceName` allows you to [create a named instance](https://www.browsersync.io/docs/api#api-create). The default value is `undefined` (anonymous instance).
+N.B.:
+`logSnippet` is disabled by default. Also, `instanceName` allows you to [create a named instance](https://www.browsersync.io/docs/api#api-create). The default value is `undefined` (anonymous instance).
+`injectTag` is `</ body>` by default. Change tags to inject Browsersync snippets.
 
 ## License
 

--- a/lib/browsersync.js
+++ b/lib/browsersync.js
@@ -11,6 +11,7 @@ module.exports = function (app) {
   var self = this;
   var bsConfig = self.config.browsersync || {};
   var bsInstanceName = bsConfig.instanceName || undefined;
+  var injectTag = bsConfig.injectTag || '</body>';
   var bs = browsersync.create(bsInstanceName);
   var opts = Object.assign({}, bsConfigDefaults, bsConfig);
   var snippet = '';
@@ -23,7 +24,7 @@ module.exports = function (app) {
 
   function converter(content, req, res, callback) {
     var op = content.toString();
-    var pos = op.lastIndexOf('</body>');
+    var pos = op.lastIndexOf(injectTag);
 
     if (!~pos) {
       return callback(null, content);


### PR DESCRIPTION
This pull request introduces a new option.
It changes tags to inject Browsersync's snippets.

This is a workaround for #15 . (I could not solve the root cause of #15 )

Browsersync may not work if the same problem as issue #15 occurs. Because the snippet for Browsersync is injected into `</ body>`. The #15 issue causes `</ body>` not to be rendered, which can cause Browsersync to fail.

The option introduced by this pull request allows you to move the tag to be injected into the first half of the code.
This will avoid this problem. It is rendered reliably by being injected into the <body> tag.

This option allows to use the Browsersync feature until #15 is resolved.

Alternatively, this option can provide a solution for themes without <body> tags.
For example, it is recommended that the [[Google HTML/CSS Style Guide](https://google.github.io/styleguide/htmlcssguide.html#Optional_Tags)] not use the optional `<body>` tag. This plugin can not be used than it is.

However, if this pull request makes other tags available, then the plug-in will be available.
Like this, it is a function that can be used not only for the #15 workaround but also for others.